### PR TITLE
Fix "error: unused while label" when building with zig 0.6.0+a50260470

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -67,7 +67,7 @@ const DependencyGraph = struct {
 
             try self.results.append(result);
             var it_line = std.mem.tokenize(result.stdout, "\n");
-            iterate: while (it_line.next()) |line| {
+            while (it_line.next()) |line| {
                 var name: []const u8 = undefined;
                 var path: []const u8 = undefined;
                 var root: []const u8 = undefined;


### PR DESCRIPTION
When attempting to build this locally I run these commands:

```sh
git clone https://github.com/mattnite/zkg.git
cd zkg
zig build
```

The build fails for me with this error:

```
./src/main.zig:70:22: error: unused while label
            iterate: while (it_line.next()) |line| {
                     ^
```

<details><summary>Full Log</summary>

```
./src/main.zig:70:22: error: unused while label
            iterate: while (it_line.next()) |line| {
                     ^
./src/main.zig:46:37: note: referenced here
            const result = try front.zkg_runner();
                                    ^
./src/main.zig:181:13: note: referenced here
            os.access(imports_file, 0) catch |err| {
            ^
./src/main.zig:181:15: note: referenced here
            os.access(imports_file, 0) catch |err| {
              ^
./src/main.zig:184:33: note: referenced here
                        .term = ChildProcess.Term{ .Exited = 0 },
                                ^
./src/main.zig:10:20: note: referenced here
const Builder = std.build.Builder;
                   ^
./src/main.zig:10:26: note: referenced here
const Builder = std.build.Builder;
                         ^
./src/main.zig:207:33: note: referenced here
            const builder = try Builder.create(self.allocator, "zig", self.base_path, cache_dir);
                                ^
/usr/lib/zig/std/build.zig:10:13: note: referenced here
const mem = std.mem;
            ^
/usr/lib/zig/std/build.zig:17:19: note: referenced here
const Allocator = mem.Allocator;
                  ^
/usr/lib/zig/std/build.zig:124:21: note: referenced here
        allocator: *Allocator,
                    ^
/usr/lib/zig/std/build.zig:33:18: note: referenced here
    install_tls: TopLevelStep,
                 ^
/usr/lib/zig/std/build.zig:119:15: note: referenced here
        step: Step,
              ^
/usr/lib/zig/std/build.zig:2549:9: note: referenced here
    id: Id,
        ^
/usr/lib/zig/std/build.zig:2552:19: note: referenced here
    dependencies: ArrayList(*Step),
                  ^
/usr/lib/zig/std/array_list.zig:29:16: note: referenced here
        items: Slice,
               ^
/usr/lib/zig/std/std.zig:37:35: note: referenced here
pub const StringHashMap = hash_map.StringHashMap;
                                  ^
/usr/lib/zig/std/build.zig:16:26: note: referenced here
const StringHashMap = std.StringHashMap;
                         ^
/usr/lib/zig/std/build.zig:88:33: note: referenced here
    const UserInputOptionsMap = StringHashMap(UserInputOption);
                                ^
/usr/lib/zig/std/build.zig:88:47: note: referenced here
    const UserInputOptionsMap = StringHashMap(UserInputOption);
                                              ^
/usr/lib/zig/std/hash_map.zig:51:35: note: referenced here
    return HashMap([]const u8, V, hashString, eqlString, DefaultMaxLoadPercentage);
                                  ^
/usr/lib/zig/std/hash_map.zig:51:47: note: referenced here
    return HashMap([]const u8, V, hashString, eqlString, DefaultMaxLoadPercentage);
                                              ^
/usr/lib/zig/std/build.zig:36:25: note: referenced here
    user_input_options: UserInputOptionsMap,
                        ^
/usr/lib/zig/std/hash_map.zig:84:20: note: referenced here
        unmanaged: Unmanaged,
                   ^
/usr/lib/zig/std/hash_map.zig:258:23: note: referenced here
        metadata: ?[*]Metadata = null,
                      ^
/usr/lib/zig/std/hash_map.zig:308:26: note: referenced here
            fingerprint: FingerPrint = 0,
                         ^
/usr/lib/zig/std/hash_map.zig:261:15: note: referenced here
        size: Size = 0,
              ^
/usr/lib/zig/std/build.zig:89:47: note: referenced here
    const AvailableOptionsMap = StringHashMap(AvailableOption);
                                              ^
/usr/lib/zig/std/build.zig:37:28: note: referenced here
    available_options_map: AvailableOptionsMap,
                           ^
/usr/lib/zig/std/build.zig:93:18: note: referenced here
        type_id: TypeId,
                 ^
/usr/lib/zig/std/std.zig:18:42: note: referenced here
pub const BufMap = @import("buf_map.zig").BufMap;
                                         ^
/usr/lib/zig/std/build.zig:20:19: note: referenced here
const BufMap = std.BufMap;
                  ^
/usr/lib/zig/std/build.zig:51:15: note: referenced here
    env_map: *BufMap,
              ^
/usr/lib/zig/std/buf_map.zig:7:23: note: referenced here
const StringHashMap = std.StringHashMap;
                      ^
/usr/lib/zig/std/buf_map.zig:17:27: note: referenced here
    const BufMapHashMap = StringHashMap([]const u8);
                          ^
/usr/lib/zig/std/buf_map.zig:15:15: note: referenced here
    hash_map: BufMapHashMap,
              ^
/usr/lib/zig/std/build.zig:60:32: note: referenced here
    installed_files: ArrayList(InstalledFile),
                               ^
/usr/lib/zig/std/build.zig:2686:10: note: referenced here
    dir: InstallDir,
         ^
/usr/lib/zig/std/build.zig:63:20: note: referenced here
    release_mode: ?builtin.Mode,
                   ^
/usr/lib/zig/std/build.zig:66:17: note: referenced here
    vcpkg_root: VcpkgRoot,
                ^
/usr/lib/zig/std/build.zig:2662:25: note: referenced here
const VcpkgRoot = union(VcpkgRootStatus) {
                        ^
/usr/lib/zig/std/build.zig:67:28: note: referenced here
    pkg_config_pkg_list: ?(PkgConfigError![]const PkgConfigPkg) = null,
                           ^
/usr/lib/zig/std/build.zig:67:51: note: referenced here
    pkg_config_pkg_list: ?(PkgConfigError![]const PkgConfigPkg) = null,
                                                  ^
./src/main.zig:207:40: note: referenced here
            const builder = try Builder.create(self.allocator, "zig", self.base_path, cache_dir);
                                       ^
/usr/lib/zig/std/build.zig:130:25: note: referenced here
        env_map.* = try process.getEnvMap(allocator);
                        ^
/usr/lib/zig/std/process.zig:61:30: note: referenced here
pub fn getEnvMap(allocator: *Allocator) !BufMap {
                             ^
/usr/lib/zig/std/process.zig:61:42: note: referenced here
pub fn getEnvMap(allocator: *Allocator) !BufMap {
                                         ^
/usr/lib/zig/std/build.zig:130:32: note: referenced here
        env_map.* = try process.getEnvMap(allocator);
                               ^
/usr/lib/zig/std/buf_map.zig:9:19: note: referenced here
const Allocator = mem.Allocator;
                  ^
/usr/lib/zig/std/buf_map.zig:19:29: note: referenced here
    pub fn init(allocator: *Allocator) BufMap {
                            ^
/usr/lib/zig/std/process.zig:62:24: note: referenced here
    var result = BufMap.init(allocator);
                       ^
/usr/lib/zig/std/process.zig:141:23: note: referenced here
            try result.set(key, value);
                      ^
/usr/lib/zig/std/buf_map.zig:49:36: note: referenced here
        const value_copy = try self.copy(value);
                                   ^
/usr/lib/zig/std/hash_map.zig:130:32: note: referenced here
        pub fn getOrPut(self: *Self, key: K) !GetOrPutResult {
                               ^
/usr/lib/zig/std/hash_map.zig:92:45: note: referenced here
        pub const GetOrPutResult = Unmanaged.GetOrPutResult;
                                            ^
/usr/lib/zig/std/hash_map.zig:130:47: note: referenced here
        pub fn getOrPut(self: *Self, key: K) !GetOrPutResult {
                                              ^
/usr/lib/zig/std/hash_map.zig:370:21: note: referenced here
            entry: *Entry,
                    ^
/usr/lib/zig/std/buf_map.zig:51:45: note: referenced here
        const get_or_put = try self.hash_map.getOrPut(key);
                                            ^
/usr/lib/zig/std/hash_map.zig:616:32: note: referenced here
        pub fn getOrPut(self: *Self, allocator: *Allocator, key: K) !GetOrPutResult {
                               ^
/usr/lib/zig/std/hash_map.zig:131:34: note: referenced here
            return self.unmanaged.getOrPut(self.allocator, key);
                                 ^
/usr/lib/zig/std/hash_map.zig:617:21: note: referenced here
            try self.growIfNeeded(allocator, 1);
                    ^
/usr/lib/zig/std/hash_map.zig:743:25: note: referenced here
                try self.grow(allocator, capacityForSize(self.load() + new_count));
                        ^
/usr/lib/zig/std/hash_map.zig:743:42: note: referenced here
                try self.grow(allocator, capacityForSize(self.load() + new_count));
                                         ^
/usr/lib/zig/std/hash_map.zig:743:62: note: referenced here
                try self.grow(allocator, capacityForSize(self.load() + new_count));
                                                             ^
/usr/lib/zig/std/hash_map.zig:773:56: note: referenced here
            const new_cap = std.math.max(new_capacity, MinimalCapacity);
                                                       ^
/usr/lib/zig/std/hash_map.zig:774:34: note: referenced here
            assert(new_cap > self.capacity());
                                 ^
/usr/lib/zig/std/hash_map.zig:779:20: note: referenced here
            try map.allocate(allocator, new_cap);
                   ^
/usr/lib/zig/std/hash_map.zig:803:39: note: referenced here
            const meta_size = @sizeOf(Header) + new_capacity * @sizeOf(Metadata);
                                      ^
/usr/lib/zig/std/hash_map.zig:778:22: note: referenced here
            defer map.deinit(allocator);
                     ^
/usr/lib/zig/std/hash_map.zig:780:16: note: referenced here
            map.initMetadatas();
               ^
/usr/lib/zig/std/hash_map.zig:787:32: note: referenced here
                var entr = self.entries();
                               ^
/usr/lib/zig/std/hash_map.zig:789:36: note: referenced here
                    if (metadata[i].isUsed()) {
                                   ^
/usr/lib/zig/std/hash_map.zig:791:28: note: referenced here
                        map.putAssumeCapacityNoClobber(entry.key, entry.value);
                           ^
/usr/lib/zig/std/hash_map.zig:619:24: note: referenced here
            return self.getOrPutAssumeCapacity(key);
                       ^
/usr/lib/zig/std/buf_map.zig:50:22: note: referenced here
        errdefer self.free(value_copy);
                     ^
/usr/lib/zig/std/hash_map.zig:212:45: note: referenced here
        pub fn remove(self: *Self, key: K) ?Entry {
                                            ^
/usr/lib/zig/std/buf_map.zig:56:34: note: referenced here
                _ = self.hash_map.remove(key);
                                 ^
/usr/lib/zig/std/process.zig:63:20: note: referenced here
    errdefer result.deinit();
                   ^
/usr/lib/zig/std/build.zig:136:31: note: referenced here
            .cache_root = try fs.path.relative(allocator, build_root, cache_root),
                              ^
/usr/lib/zig/std/build.zig:136:38: note: referenced here
            .cache_root = try fs.path.relative(allocator, build_root, cache_root),
                                     ^
/usr/lib/zig/std/fs/path.zig:1006:16: note: referenced here
        return relativePosix(allocator, from, to);
               ^
/usr/lib/zig/std/fs/path.zig:1084:31: note: referenced here
    const resolved_from = try resolvePosix(allocator, &[_][]const u8{from});
                              ^
/usr/lib/zig/std/fs/path.zig:9:16: note: referenced here
const assert = debug.assert;
               ^
/usr/lib/zig/std/fs/path.zig:599:9: note: referenced here
        assert(builtin.os.tag != .windows); // resolvePosix called on windows can't use getCwd
        ^
/usr/lib/zig/std/fs/path.zig:600:16: note: referenced here
        return process.getCwdAlloc(allocator);
               ^
/usr/lib/zig/std/fs/path.zig:600:23: note: referenced here
        return process.getCwdAlloc(allocator);
                      ^
/usr/lib/zig/std/fs/path.zig:607:13: note: referenced here
        if (isAbsolutePosix(p)) {
            ^
/usr/lib/zig/std/process.zig:31:21: note: referenced here
    var stack_buf: [fs.MAX_PATH_BYTES]u8 = undefined;
                    ^
/usr/lib/zig/std/process.zig:31:23: note: referenced here
    var stack_buf: [fs.MAX_PATH_BYTES]u8 = undefined;
                      ^
/usr/lib/zig/std/os.zig:1540:33: note: referenced here
pub fn getcwd(out_buffer: []u8) GetCwdError![]u8 {
                                ^
/usr/lib/zig/std/process.zig:37:15: note: referenced here
        if (os.getcwd(current_buf)) |slice| {
              ^
/usr/lib/zig/std/mem.zig:1208:66: note: referenced here
pub fn tokenize(buffer: []const u8, delimiter_bytes: []const u8) TokenIterator {
                                                                 ^
/usr/lib/zig/std/fs/path.zig:631:21: note: referenced here
        var it = mem.tokenize(p, "/");
                    ^
/usr/lib/zig/std/fs/path.zig:632:18: note: referenced here
        while (it.next()) |component| {
                 ^
/usr/lib/zig/std/fs/path.zig:1093:85: note: referenced here
        const from_component = from_it.next() orelse return allocator.dupe(u8, to_it.rest());
                                                                                    ^
/usr/lib/zig/std/hash_map.zig:96:44: note: referenced here
        pub fn init(allocator: *Allocator) Self {
                                           ^
/usr/lib/zig/std/build.zig:148:54: note: referenced here
            .user_input_options = UserInputOptionsMap.init(allocator),
                                                     ^
/usr/lib/zig/std/build.zig:149:57: note: referenced here
            .available_options_map = AvailableOptionsMap.init(allocator),
                                                        ^
/usr/lib/zig/std/array_list.zig:37:44: note: referenced here
        pub fn init(allocator: *Allocator) Self {
                                           ^
/usr/lib/zig/std/build.zig:150:65: note: referenced here
            .available_options_list = ArrayList(AvailableOption).init(allocator),
                                                                ^
/usr/lib/zig/std/build.zig:151:56: note: referenced here
            .top_level_steps = ArrayList(*TopLevelStep).init(allocator),
                                                       ^
/usr/lib/zig/std/build.zig:159:32: note: referenced here
            .dest_dir = env_map.get("DESTDIR"),
                               ^
/usr/lib/zig/std/build.zig:160:56: note: referenced here
            .installed_files = ArrayList(InstalledFile).init(allocator),
                                                       ^
/usr/lib/zig/std/build.zig:162:29: note: referenced here
                .step = Step.initNoOp(.TopLevel, "install", allocator),
                            ^
/usr/lib/zig/std/build.zig:166:29: note: referenced here
                .step = Step.init(.TopLevel, "uninstall", allocator, makeUninstall),
                            ^
/usr/lib/zig/std/build.zig:166:70: note: referenced here
                .step = Step.init(.TopLevel, "uninstall", allocator, makeUninstall),
                                                                     ^
/usr/lib/zig/std/build.zig:176:33: note: referenced here
        try self.top_level_steps.append(&self.install_tls);
                                ^
/usr/lib/zig/std/array_list.zig:149:42: note: referenced here
            const new_item_ptr = try self.addOne();
                                         ^
/usr/lib/zig/std/array_list.zig:292:21: note: referenced here
            try self.ensureCapacity(newlen);
                    ^
/usr/lib/zig/std/array_list.zig:276:70: note: referenced here
            const new_memory = try self.allocator.reallocAtLeast(self.allocatedSlice(), better_capacity);
                                                                     ^
/usr/lib/zig/std/array_list.zig:293:24: note: referenced here
            return self.addOneAssumeCapacity();
                       ^
./src/main.zig:210:20: note: referenced here
            builder.resolveInstallPrefix();
                   ^
/usr/lib/zig/std/build.zig:594:56: note: referenced here
    pub fn standardTargetOptions(self: *Builder, args: StandardTargetOptionsArgs) CrossTarget {
                                                       ^
/usr/lib/zig/std/build.zig:23:24: note: referenced here
const CrossTarget = std.zig.CrossTarget;
                       ^
/usr/lib/zig/std/zig.zig:17:56: note: referenced here
pub const CrossTarget = @import("zig/cross_target.zig").CrossTarget;
                                                       ^
/usr/lib/zig/std/build.zig:23:28: note: referenced here
const CrossTarget = std.zig.CrossTarget;
                           ^
/usr/lib/zig/std/build.zig:588:29: note: referenced here
        whitelist: ?[]const CrossTarget = null,
                            ^
/usr/lib/zig/std/zig/cross_target.zig:8:16: note: referenced here
const Target = std.Target;
               ^
/usr/lib/zig/std/zig/cross_target.zig:16:16: note: referenced here
    cpu_arch: ?Target.Cpu.Arch = null,
               ^
/usr/lib/zig/std/zig/cross_target.zig:18:16: note: referenced here
    cpu_model: CpuModel = CpuModel.determined_by_cpu_arch,
               ^
/usr/lib/zig/std/zig/cross_target.zig:31:22: note: referenced here
    os_version_min: ?OsVersion = null,
                     ^
/usr/lib/zig/std/zig/cross_target.zig:64:17: note: referenced here
        semver: SemVer,
                ^
/usr/lib/zig/std/zig/cross_target.zig:70:37: note: referenced here
    pub const DynamicLinker = Target.DynamicLinker;
                                    ^
/usr/lib/zig/std/zig/cross_target.zig:46:21: note: referenced here
    dynamic_linker: DynamicLinker = DynamicLinker{},
                    ^
./src/main.zig:213:35: note: referenced here
            const target = builder.standardTargetOptions(.{});
                                  ^
/usr/lib/zig/std/zig/cross_target.zig:21:70: note: referenced here
    cpu_features_add: Target.Cpu.Feature.Set = Target.Cpu.Feature.Set.empty,
                                                                     ^
./src/main.zig:214:33: note: referenced here
            const mode = builder.standardReleaseOptions();
                                ^
/usr/lib/zig/std/build.zig:211:84: note: referenced here
    pub fn addExecutable(self: *Builder, name: []const u8, root_src: ?[]const u8) *LibExeObjStep {
                                                                                   ^
/usr/lib/zig/std/build.zig:1182:15: note: referenced here
    version: ?Version,
              ^
/usr/lib/zig/std/build.zig:1184:11: note: referenced here
    kind: Kind,
          ^
/usr/lib/zig/std/std.zig:19:42: note: referenced here
pub const BufSet = @import("buf_set.zig").BufSet;
                                         ^
/usr/lib/zig/std/build.zig:19:19: note: referenced here
const BufSet = std.BufSet;
                  ^
/usr/lib/zig/std/build.zig:1190:17: note: referenced here
    frameworks: BufSet,
                ^
/usr/lib/zig/std/buf_set.zig:7:23: note: referenced here
const StringHashMap = std.StringHashMap;
                      ^
/usr/lib/zig/std/buf_set.zig:15:27: note: referenced here
    const BufSetHashMap = StringHashMap(void);
                          ^
/usr/lib/zig/std/buf_set.zig:13:15: note: referenced here
    hash_map: BufSetHashMap,
              ^
/usr/lib/zig/std/build.zig:1202:19: note: referenced here
    c_std: Builder.CStd,
                  ^
/usr/lib/zig/std/build.zig:1210:24: note: referenced here
    code_model: builtin.CodeModel = .default,
                       ^
/usr/lib/zig/std/build.zig:1212:16: note: referenced here
    root_src: ?FileSource,
               ^
/usr/lib/zig/std/build.zig:27:58: note: referenced here
pub const WriteFileStep = @import("build/write_file.zig").WriteFileStep;
                                                         ^
/usr/lib/zig/std/build.zig:1145:16: note: referenced here
        step: *WriteFileStep,
               ^
/usr/lib/zig/std/build/write_file.zig:8:14: note: referenced here
const Step = build.Step;
             ^
/usr/lib/zig/std/build/write_file.zig:15:11: note: referenced here
    step: Step,
          ^
/usr/lib/zig/std/build/write_file.zig:16:15: note: referenced here
    builder: *Builder,
              ^
/usr/lib/zig/std/build/write_file.zig:12:19: note: referenced here
const ArrayList = std.ArrayList;
                  ^
/usr/lib/zig/std/build/write_file.zig:18:12: note: referenced here
    files: ArrayList(File),
           ^
/usr/lib/zig/std/build/write_file.zig:18:22: note: referenced here
    files: ArrayList(File),
                     ^
/usr/lib/zig/std/build.zig:26:60: note: referenced here
pub const TranslateCStep = @import("build/translate_c.zig").TranslateCStep;
                                                           ^
/usr/lib/zig/std/build.zig:1148:19: note: referenced here
    translate_c: *TranslateCStep,
                  ^
/usr/lib/zig/std/build/translate_c.zig:7:15: note: referenced here
const build = std.build;
              ^
/usr/lib/zig/std/build/translate_c.zig:8:14: note: referenced here
const Step = build.Step;
             ^
/usr/lib/zig/std/build/translate_c.zig:18:11: note: referenced here
    step: Step,
          ^
/usr/lib/zig/std/build/translate_c.zig:19:15: note: referenced here
    builder: *Builder,
              ^
/usr/lib/zig/std/build/translate_c.zig:24:13: note: referenced here
    target: CrossTarget = CrossTarget{},
            ^
/usr/lib/zig/std/build.zig:1216:25: note: referenced here
    packages: ArrayList(Pkg),
                        ^
/usr/lib/zig/std/build.zig:1218:48: note: referenced here
    build_options_artifact_args: std.ArrayList(BuildOptionArtifactArg),
                                               ^
/usr/lib/zig/std/build.zig:1223:29: note: referenced here
    link_objects: ArrayList(LinkObject),
                            ^
/usr/lib/zig/std/build.zig:1272:23: note: referenced here
        CSourceFile: *CSourceFile,
                      ^
/usr/lib/zig/std/build.zig:1224:29: note: referenced here
    include_dirs: ArrayList(IncludeDir),
                            ^
/usr/lib/zig/std/build.zig:1233:21: note: referenced here
    install_step: ?*InstallArtifactStep,
                    ^
/usr/lib/zig/std/builtin.zig:24:33: note: referenced here
pub const SubSystem = std.Target.SubSystem;
                                ^
/usr/lib/zig/std/build.zig:1265:24: note: referenced here
    subsystem: ?builtin.SubSystem = null,
                       ^
./src/main.zig:216:32: note: referenced here
            const exe = builder.addExecutable("zkg_runner", source);
                               ^
./src/main.zig:222:16: note: referenced here
            exe.setTarget(target);
               ^
./src/main.zig:223:16: note: referenced here
            exe.setBuildMode(mode);
               ^
./src/main.zig:224:16: note: referenced here
            exe.linkSystemLibrary("git2");
               ^
./src/main.zig:227:16: note: referenced here
            exe.addPackage(zkg);
               ^
./src/main.zig:234:16: note: referenced here
            exe.addIncludeDir(lib_dir);
               ^
./src/main.zig:236:16: note: referenced here
            exe.install();
               ^
./src/main.zig:238:24: note: referenced here
            try builder.make(&[_][]const u8{});
                       ^
/usr/lib/zig/std/build.zig:357:17: note: referenced here
        try self.makePath(self.cache_root);
                ^
/usr/lib/zig/std/build.zig:830:17: note: referenced here
        fs.cwd().makePath(self.pathFromRoot(path)) catch |err| {
                ^
/usr/lib/zig/std/build.zig:830:31: note: referenced here
        fs.cwd().makePath(self.pathFromRoot(path)) catch |err| {
                              ^
/usr/lib/zig/std/fs.zig:940:17: note: referenced here
            self.makeDir(sub_path[0..end_index]) catch |err| switch (err) {
                ^
/usr/lib/zig/std/os.zig:2075:67: note: referenced here
pub fn mkdirat(dir_fd: fd_t, sub_dir_path: []const u8, mode: u32) MakeDirError!void {
                                                                  ^
/usr/lib/zig/std/fs.zig:922:15: note: referenced here
        try os.mkdirat(self.fd, sub_path, default_new_dir_mode);
              ^
/usr/lib/zig/std/fs.zig:922:43: note: referenced here
        try os.mkdirat(self.fd, sub_path, default_new_dir_mode);
                                          ^
/usr/lib/zig/std/fs.zig:952:33: note: referenced here
                        if (path.isSep(sub_path[end_index])) break;
                                ^
/usr/lib/zig/std/build.zig:831:13: note: referenced here
            warn("Unable to create path {}: {}\n", .{ path, @errorName(err) });
            ^
/usr/lib/zig/std/build.zig:359:44: note: referenced here
        var wanted_steps = ArrayList(*Step).init(self.allocator);
                                           ^
/usr/lib/zig/std/build.zig:363:29: note: referenced here
            try wanted_steps.append(self.default_step);
                            ^
/usr/lib/zig/std/build.zig:360:27: note: referenced here
        defer wanted_steps.deinit();
                          ^
/usr/lib/zig/std/build.zig:366:35: note: referenced here
                const s = try self.getTopLevelStepByName(step_name);
                                  ^
/usr/lib/zig/std/build.zig:421:34: note: referenced here
        for (self.top_level_steps.span()) |top_level_step| {
                                 ^
/usr/lib/zig/std/build.zig:371:26: note: referenced here
        for (wanted_steps.span()) |s| {
                         ^
/usr/lib/zig/std/build.zig:372:21: note: referenced here
            try self.makeOneStep(s);
                    ^
./src/main.zig:208:26: note: referenced here
            defer builder.destroy();
                         ^
/usr/lib/zig/std/child_process.zig:15:13: note: referenced here
const mem = std.mem;
            ^
/usr/lib/zig/std/child_process.zig:192:21: note: referenced here
        allocator: *mem.Allocator,
                    ^
/usr/lib/zig/std/child_process.zig:195:19: note: referenced here
        cwd_dir: ?fs.Dir = null,
                  ^
/usr/lib/zig/std/child_process.zig:196:26: note: referenced here
        env_map: ?*const BufMap = null,
                         ^
/usr/lib/zig/std/child_process.zig:63:28: note: referenced here
    pub const Arg0Expand = os.Arg0Expand;
                           ^
/usr/lib/zig/std/child_process.zig:63:30: note: referenced here
    pub const Arg0Expand = os.Arg0Expand;
                             ^
/usr/lib/zig/std/child_process.zig:198:22: note: referenced here
        expand_arg0: Arg0Expand = .no_expand,
                     ^
./src/main.zig:241:36: note: referenced here
            return std.ChildProcess.exec(.{
                                   ^
/usr/lib/zig/std/fs.zig:1277:35: note: referenced here
    pub const DeleteFileError = os.UnlinkError;
                                  ^
/usr/lib/zig/std/fs.zig:1281:56: note: referenced here
    pub fn deleteFile(self: Dir, sub_path: []const u8) DeleteFileError!void {
                                                       ^
./src/main.zig:239:31: note: referenced here
            defer std.fs.cwd().deleteFile("zig-cache/bin/zkg_runner") catch {};
                              ^
/usr/lib/zig/std/child_process.zig:25:14: note: referenced here
    pid: if (builtin.os.tag == .windows) void else i32,
             ^
/usr/lib/zig/std/child_process.zig:31:13: note: referenced here
    stdin: ?File,
            ^
/usr/lib/zig/std/child_process.zig:78:12: note: referenced here
    } || os.ExecveError || os.SetIdError || os.ChangeCurDirError || windows.CreateProcessError || windows.WaitForSingleObjectError;
           ^
/usr/lib/zig/std/os.zig:2487:55: note: referenced here
pub const SetIdError = error{ResourceLimitReached} || SetEidError;
                                                      ^
/usr/lib/zig/std/child_process.zig:78:30: note: referenced here
    } || os.ExecveError || os.SetIdError || os.ChangeCurDirError || windows.CreateProcessError || windows.WaitForSingleObjectError;
                             ^
/usr/lib/zig/std/child_process.zig:78:47: note: referenced here
    } || os.ExecveError || os.SetIdError || os.ChangeCurDirError || windows.CreateProcessError || windows.WaitForSingleObjectError;
                                              ^
/usr/lib/zig/std/child_process.zig:14:19: note: referenced here
const windows = os.windows;
                  ^
/usr/lib/zig/std/child_process.zig:78:69: note: referenced here
    } || os.ExecveError || os.SetIdError || os.ChangeCurDirError || windows.CreateProcessError || windows.WaitForSingleObjectError;
                                                                    ^
/usr/lib/zig/std/os/windows/bits.zig:920:28: note: referenced here
pub usingnamespace switch (builtin.arch) {
                           ^
/usr/lib/zig/std/child_process.zig:78:76: note: referenced here
    } || os.ExecveError || os.SetIdError || os.ChangeCurDirError || windows.CreateProcessError || windows.WaitForSingleObjectError;
                                                                           ^
/usr/lib/zig/std/child_process.zig:78:106: note: referenced here
    } || os.ExecveError || os.SetIdError || os.ChangeCurDirError || windows.CreateProcessError || windows.WaitForSingleObjectError;
                                                                                                         ^
/usr/lib/zig/std/child_process.zig:35:13: note: referenced here
    term: ?(SpawnError!Term),
            ^
/usr/lib/zig/std/child_process.zig:42:21: note: referenced here
    stdin_behavior: StdIo,
                    ^
/usr/lib/zig/std/child_process.zig:200:39: note: referenced here
        const child = try ChildProcess.init(args.argv, args.allocator);
                                      ^
/usr/lib/zig/std/child_process.zig:211:18: note: referenced here
        try child.spawn();
                 ^
/usr/lib/zig/std/child_process.zig:201:20: note: referenced here
        defer child.deinit();
                   ^
/usr/lib/zig/std/fs/file.zig:768:33: note: referenced here
    pub fn inStream(file: File) Reader {
                                ^
/usr/lib/zig/std/child_process.zig:213:41: note: referenced here
        const stdout_in = child.stdout.?.inStream();
                                        ^
/usr/lib/zig/std/io/reader.zig:88:35: note: referenced here
        pub fn readAllAlloc(self: Self, allocator: *mem.Allocator, max_size: usize) ![]u8 {
                                  ^
/usr/lib/zig/std/child_process.zig:217:37: note: referenced here
        const stdout = try stdout_in.readAllAlloc(args.allocator, args.max_output_bytes);
                                    ^
/usr/lib/zig/std/io/reader.zig:91:21: note: referenced here
            try self.readAllArrayList(&array_list, max_size);
                    ^
/usr/lib/zig/std/io/reader.zig:60:43: note: referenced here
            try array_list.ensureCapacity(math.min(max_append_size, 4096));
                                          ^
/usr/lib/zig/std/io/reader.zig:64:27: note: referenced here
                array_list.expandToCapacity();
                          ^
/usr/lib/zig/std/io/reader.zig:65:46: note: referenced here
                const dest_slice = array_list.span()[start_index..];
                                             ^
/usr/lib/zig/std/io/reader.zig:38:50: note: referenced here
        pub fn readAll(self: Self, buffer: []u8) Error!usize {
                                                 ^
/usr/lib/zig/std/io/reader.zig:66:44: note: referenced here
                const bytes_read = try self.readAll(dest_slice);
                                           ^
/usr/lib/zig/std/child_process.zig:223:30: note: referenced here
            .term = try child.wait(),
                             ^
/usr/lib/zig/std/child_process.zig:177:24: note: referenced here
            return self.waitPosix();
                       ^
/usr/lib/zig/std/child_process.zig:241:17: note: referenced here
            self.cleanupStreams();
                ^
/usr/lib/zig/std/child_process.zig:245:13: note: referenced here
        self.waitUnwrapped();
            ^
./src/main.zig:50:25: note: referenced here
                        debug.print("{}", .{result.stderr});
                        ^
./src/main.zig:68:29: note: referenced here
            try self.results.append(result);
                            ^
./src/main.zig:99:30: note: referenced here
                    try front.connect_dependency(node, name, root);
                             ^
./src/main.zig:161:34: note: referenced here
            try self.dependencies.append(DependencyEdge{
                                 ^
./src/main.zig:166:31: note: referenced here
            try dep.dependents.append(self);
                              ^
./src/main.zig:105:25: note: referenced here
                try self.validate();
                        ^
./src/main.zig:113:35: note: referenced here
            for (node.dependencies.span()) |dep| {
                                  ^
./src/main.zig:119:33: note: referenced here
            for (node.dependents.span()) |dep| {
                                ^
./src/main.zig:258:45: note: referenced here
    var cache_dir = std.fs.Dir{ .fd = try os.open("zig-cache", os.O_DIRECTORY, 0) };
                                            ^
./src/main.zig:258:66: note: referenced here
    var cache_dir = std.fs.Dir{ .fd = try os.open("zig-cache", os.O_DIRECTORY, 0) };
                                                                 ^
/usr/lib/zig/std/fs.zig:800:67: note: referenced here
    pub fn createFile(self: Dir, sub_path: []const u8, flags: File.CreateFlags) File.OpenError!File {
                                                                  ^
./src/main.zig:261:35: note: referenced here
    const gen_file = try cache_dir.createFile("packages.zig", std.fs.File.CreateFlags{
                                  ^
/usr/lib/zig/std/fs/file.zig:148:22: note: referenced here
        mode: Mode = default_mode,
                     ^
/usr/lib/zig/std/fs/file.zig:153:47: note: referenced here
        intended_io_mode: io.ModeOverride = io.default_mode,
                                              ^
./src/main.zig:259:20: note: referenced here
    defer cache_dir.close();
                   ^
./src/main.zig:267:33: note: referenced here
    const file_stream = gen_file.outStream();
                                ^
./src/main.zig:289:24: note: referenced here
    stream: std.fs.File.OutStream,
                       ^
./src/main.zig:277:13: note: referenced here
        try recursive_print(allocator, file_stream, dep, 1);
            ^
zkg...The following command exited with error code 1:
/usr/bin/zig build-exe /projects/zkg/src/main.zig --cache-dir /projects/zkg/zig-cache --name zkg --cache on 

Build failed. The following command failed:
/projects/zkg/zig-cache/o/tZ2fRJ6H3h4fhXc6HQoZQHIjikiNXxSwyP_qIefU1Y4Ax_U2gp-_gXz11O3Ly7K8/build /usr/bin/zig /projects/zkg /projects/zkg/zig-cache install
```
</details>

I can successfully compile it by removing the `iterate:` label:

```diff
diff --git a/src/main.zig b/src/main.zig
index b62a91a..c401f0a 100644
--- a/src/main.zig
+++ b/src/main.zig
@@ -67,7 +67,7 @@ const DependencyGraph = struct {
 
             try self.results.append(result);
             var it_line = std.mem.tokenize(result.stdout, "\n");
-            iterate: while (it_line.next()) |line| {
+            while (it_line.next()) |line| {
                 var name: []const u8 = undefined;
                 var path: []const u8 = undefined;
                 var root: []const u8 = undefined;
```

I am running:

```
$ zig version
0.6.0+a50260470

$ uname -r
5.8.6-1-MANJARO
```

Thanks! :sunglasses: 